### PR TITLE
Replace Fake CpuTrend with Real Host Uptime History

### DIFF
--- a/dashboard/src/components/charts/HostUptimeHistory.tsx
+++ b/dashboard/src/components/charts/HostUptimeHistory.tsx
@@ -1,0 +1,37 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { useEffect, useState } from 'react';
+
+interface HistoryPoint {
+  time: string;
+  up: number;
+  down: number;
+}
+
+export default function HostUptimeHistory() {
+  const [data, setData] = useState<HistoryPoint[]>([]);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      const res = await fetch('http://localhost:4000/api/poll-history');
+      const json = await res.json();
+      setData(json);
+    };
+    fetchHistory();
+  }, []);
+
+  return (
+    <div className="w-full h-64">
+      <ResponsiveContainer>
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" tickFormatter={(t) => new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="up" stackId="a" fill="#4ade80" />
+          <Bar dataKey="down" stackId="a" fill="#f87171" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/dashboard/src/components/charts/HostUptimeHistory.tsx
+++ b/dashboard/src/components/charts/HostUptimeHistory.tsx
@@ -8,23 +8,36 @@ interface HistoryPoint {
 }
 
 export default function HostUptimeHistory() {
-  const [data, setData] = useState<HistoryPoint[]>([]);
+  const [data, setData] = useState<HistoryPoint[] | null>(null);
 
   useEffect(() => {
     const fetchHistory = async () => {
-      const res = await fetch('http://localhost:4000/api/poll-history');
-      const json = await res.json();
-      setData(json);
+      try {
+        const res = await fetch('http://localhost:4000/api/poll-history');
+        const json = await res.json();
+        setData(json);
+      } catch (e) {
+        console.error('Error fetching poll history:', e);
+        setData([]);
+      }
     };
     fetchHistory();
   }, []);
+
+  if (data === null) return <div className="text-sm text-gray-500">Loading...</div>;
+  if (data.length === 0) return <div className="text-sm text-gray-500">No poll data yet</div>;
 
   return (
     <div className="w-full h-64">
       <ResponsiveContainer>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="time" tickFormatter={(t) => new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} />
+          <XAxis
+            dataKey="time"
+            tickFormatter={(t) =>
+              new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+            }
+          />
           <YAxis />
           <Tooltip />
           <Legend />

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import HostStatusPie from '../components/charts/HostStatusPie';
-import CpuTrend from '../components/charts/CpuTrend';
+import HostUptimeHistory from '../components/charts/HostUptimeHistory';
 import TopVMsChart from '../components/charts/TopVMsChart';
 import HostKPI from '../components/HostKPI';
 import type { Host } from '../api/types';
@@ -90,9 +90,10 @@ export default function Dashboard() {
           </div>
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
             <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">
-              Avg CPU (All Hosts)
+              Host Uptime – Last 5 Polls
             </h2>
-            <CpuTrend hosts={hosts} />
+            <HostUptimeHistory />
+
           </div>
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
             <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">

--- a/server/prisma/migrations/20250610220548_add_poll_history/migration.sql
+++ b/server/prisma/migrations/20250610220548_add_poll_history/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "PollHistory" (
+    "id" SERIAL NOT NULL,
+    "time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "up" INTEGER NOT NULL,
+    "down" INTEGER NOT NULL,
+
+    CONSTRAINT "PollHistory_pkey" PRIMARY KEY ("id")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -7,6 +7,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model PollHistory {
+  id        Int      @id @default(autoincrement())
+  time      DateTime @default(now())
+  up        Int
+  down      Int
+}
+
 model Host {
   id            Int      @id @default(autoincrement())
   name          String   @unique

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { PrismaClient } from '@prisma/client';
 import hostRoutes from './routes/host.routes';
 import vmRoutes from './routes/vm.routes';
 import { startPollingJob } from './jobs/poll-scheduler';
+import pollHistoryRouter from './routes/api/poll-history';
 
 dotenv.config();
 
@@ -21,6 +22,7 @@ app.get('/', (_req: Request, res: Response) => {
 
 app.use('/api/hosts', hostRoutes);
 app.use('/api/vms', vmRoutes);
+app.use('/api', pollHistoryRouter);
 
 startPollingJob();
 

--- a/server/src/routes/api/poll-history.ts
+++ b/server/src/routes/api/poll-history.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+
+const router = express.Router();
+const HISTORY_FILE = path.resolve(__dirname, '../../../poll_history.json');
+
+router.get('/poll-history', async (_, res) => {
+  try {
+    const file = await fs.readFile(HISTORY_FILE, 'utf8');
+    const data = JSON.parse(file);
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: 'Could not load poll history' });
+  }
+});
+
+export default router;

--- a/server/src/routes/api/poll-history.ts
+++ b/server/src/routes/api/poll-history.ts
@@ -10,7 +10,12 @@ router.get('/poll-history', async (_, res) => {
     const file = await fs.readFile(HISTORY_FILE, 'utf8');
     const data = JSON.parse(file);
     res.json(data);
-  } catch (e) {
+  } catch (err) {
+    if ((err as any).code === 'ENOENT') {
+      // File doesn't exist — return empty array
+      return res.json([]);
+    }
+    console.error('Error reading poll history:', err);
     res.status(500).json({ error: 'Could not load poll history' });
   }
 });

--- a/server/src/routes/api/poll-history.ts
+++ b/server/src/routes/api/poll-history.ts
@@ -1,21 +1,18 @@
 import express from 'express';
-import fs from 'fs/promises';
-import path from 'path';
+import { PrismaClient } from '@prisma/client';
 
 const router = express.Router();
-const HISTORY_FILE = path.resolve(__dirname, '../../../poll_history.json');
+const prisma = new PrismaClient();
 
 router.get('/poll-history', async (_, res) => {
   try {
-    const file = await fs.readFile(HISTORY_FILE, 'utf8');
-    const data = JSON.parse(file);
-    res.json(data);
+    const history = await prisma.pollHistory.findMany({
+      orderBy: { time: 'desc' },
+      take: 5,
+    });
+    res.json(history);
   } catch (err) {
-    if ((err as any).code === 'ENOENT') {
-      // File doesn't exist — return empty array
-      return res.json([]);
-    }
-    console.error('Error reading poll history:', err);
+    console.error('Error fetching poll history:', err);
     res.status(500).json({ error: 'Could not load poll history' });
   }
 });


### PR DESCRIPTION
### Problem

The previous `CpuTrend` chart simulated 12-hour CPU usage with random values. This was misleading and not tied to real polling data, creating a false sense of observability.

---

### What This PR Changes

This PR introduces a new `PollHistory` model in Prisma and stores poll data directly in the PostgreSQL database. It also:
- Adds a `/api/poll-history` endpoint to return the 5 most recent poll records
- Updates the frontend chart to pull this data safely
- Logs snapshot on each polling run from `pollHosts.ts`
- Creates a new `HostUptimeHistory.tsx` component that reads and displays the data
- Replaces `CpuTrend` chart in the Dashboard with real uptime trends

---

Closes: #9 

