### PR TITLE
Centralized Polling Integration Complete

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './components/Layout';
 import RequireAuth from './components/RequireAuth';
 import { AuthProvider } from './context/AuthContext';
+import { PollingProvider } from './context/PollingContext';
 
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/Dashboard';
@@ -12,18 +13,18 @@ export default function App() {
   return (
     <AuthProvider>
       <Routes>
-        {/* Redirect root path to /dashboard */}
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
-
         <Route path="/login" element={<LoginPage />} />
-        
+
         <Route
           path="/dashboard"
           element={
             <RequireAuth>
-              <Layout>
-                <DashboardPage />
-              </Layout>
+              <PollingProvider>
+                <Layout>
+                  <DashboardPage />
+                </Layout>
+              </PollingProvider>
             </RequireAuth>
           }
         />
@@ -31,9 +32,11 @@ export default function App() {
           path="/hosts"
           element={
             <RequireAuth>
-              <Layout>
-                <HostsPage />
-              </Layout>
+              <PollingProvider>
+                <Layout>
+                  <HostsPage />
+                </Layout>
+              </PollingProvider>
             </RequireAuth>
           }
         />
@@ -41,9 +44,11 @@ export default function App() {
           path="/vms"
           element={
             <RequireAuth>
-              <Layout>
-                <VMsPage />
-              </Layout>
+              <PollingProvider>
+                <Layout>
+                  <VMsPage />
+                </Layout>
+              </PollingProvider>
             </RequireAuth>
           }
         />

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,16 +1,25 @@
 import { useState, type ReactNode } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
+import { usePolling } from '../context/PollingContext';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { lastUpdated } = usePolling();
 
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <Sidebar collapsed={sidebarCollapsed} />
       <div className="flex-1 flex flex-col">
         <Header onToggleSidebar={() => setSidebarCollapsed((prev) => !prev)} />
-        <main className="flex-1 p-6 space-y-6">{children}</main>
+        <main className="flex-1 p-6 space-y-6">
+          {lastUpdated && (
+            <div className="text-sm text-gray-500 dark:text-gray-400 text-right">
+              Last updated: {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </div>
+          )}
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,11 +1,9 @@
 import { useState, type ReactNode } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
-import { usePolling } from '../context/PollingContext';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const { lastUpdated } = usePolling();
 
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -13,11 +11,6 @@ export default function Layout({ children }: { children: ReactNode }) {
       <div className="flex-1 flex flex-col">
         <Header onToggleSidebar={() => setSidebarCollapsed((prev) => !prev)} />
         <main className="flex-1 p-6 space-y-6">
-          {lastUpdated && (
-            <div className="text-sm text-gray-500 dark:text-gray-400 text-right">
-              Last updated: {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-            </div>
-          )}
           {children}
         </main>
       </div>

--- a/dashboard/src/context/PollingContext.tsx
+++ b/dashboard/src/context/PollingContext.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import axios from 'axios';
+import type { Host, VM } from '../api/types';
+
+interface PollingData {
+  hosts: Host[];
+  vms: VM[];
+  lastUpdated: Date | null;
+  loading: boolean;
+  triggerRefresh: () => void;
+}
+
+const PollingContext = createContext<PollingData | null>(null);
+
+export function PollingProvider({ children }: { children: ReactNode }) {
+  const [hosts, setHosts] = useState<Host[]>([]);
+  const [vms, setVMs] = useState<VM[]>([]);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const [hostRes, vmRes] = await Promise.all([
+        axios.get<{ data: Host[] }>('http://localhost:4000/api/hosts'),
+        axios.get<{ data: VM[] }>('http://localhost:4000/api/vms'),
+      ]);
+      setHosts(hostRes.data.data);
+      setVMs(vmRes.data.data);
+      setLastUpdated(new Date());
+
+      // 💡 Audit placeholder
+      console.log('[Audit] Data refreshed at', new Date().toISOString());
+
+    } catch (err) {
+      console.error('Polling failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 60_000); // every 60s
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <PollingContext.Provider
+      value={{ hosts, vms, lastUpdated, loading, triggerRefresh: fetchData }}
+    >
+      {children}
+    </PollingContext.Provider>
+  );
+}
+
+export function usePolling() {
+  const ctx = useContext(PollingContext);
+  if (!ctx) throw new Error('usePolling must be used within PollingProvider');
+  return ctx;
+}


### PR DESCRIPTION
This PR finalizes the `feat/centralized-polling-context` workstream by removing duplicated UI elements and cleaning up timestamp display.

### What Changed
- Removed `Last updated: HH:mm` timestamp from `Layout.tsx` to prevent redundancy
- Retained the timestamp display inside `Dashboard.tsx` header only
- Keeps UI clean and avoids user confusion

### Context
Earlier commits added:
- `PollingContext` to manage polling across the app
- Consumed centralized host/VM data in `Dashboard`, `HostsPage`, and `VMsPage`
- Refactored all direct `axios` calls to use shared context
- Triggered manual refresh hooks and audit log stubs
- Routed polling context only under authenticated views in `App.tsx`

### Final Steps
- Verified polling runs every 60s
- Verified manual refresh updates data instantly
- Verified all pages use centralized data without duplication
- No `console.warn` or unused variables remain

---

Closes #18 
