### PR TITLE
Audit Log Viewer & Retrieval API

### DIFF
--- a/dashboard/src/api/useAuditLogs.ts
+++ b/dashboard/src/api/useAuditLogs.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export interface AuditLog {
+  id: number;
+  entity: 'Host' | 'VM';
+  entityId: number;
+  action: string;
+  field: string;
+  oldValue?: string;
+  newValue?: string;
+  user: string;
+  time: string;
+}
+
+export function useAuditLogs(entity: 'Host' | 'VM', entityId: number) {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    axios
+      .get<{ data: AuditLog[] }>(`http://localhost:4000/api/audit-logs?entity=${entity}&entityId=${entityId}`)
+      .then((res) => setLogs(res.data.data))
+      .catch((err) => console.error('Failed to load audit logs:', err))
+      .finally(() => setLoading(false));
+  }, [entity, entityId]);
+
+  return { logs, loading };
+}

--- a/dashboard/src/components/AuditTimeline.tsx
+++ b/dashboard/src/components/AuditTimeline.tsx
@@ -1,0 +1,24 @@
+import { type AuditLog } from '../api/useAuditLogs';
+
+export default function AuditTimeline({ logs }: { logs: AuditLog[] }) {
+  if (!logs.length) return <p className="text-sm text-gray-500 italic">No audit history available.</p>;
+
+  return (
+    <ul className="space-y-2 mt-4">
+      {logs.map((log) => (
+        <li key={log.id} className="text-sm text-gray-700 dark:text-gray-300 border-l pl-4 border-gray-300">
+          <p>
+            <span className="font-mono text-xs text-gray-500">{new Date(log.time).toLocaleTimeString()}</span>{' '}
+            <strong>{log.user}</strong> {log.action} <code>{log.field}</code>
+          </p>
+          {log.oldValue !== log.newValue && (
+            <p className="ml-2 text-xs text-gray-600 dark:text-gray-400">
+              {log.oldValue ? `"${log.oldValue}" → ` : ''}
+              <strong>"{log.newValue}"</strong>
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/dashboard/src/components/HostDetailModal.tsx
+++ b/dashboard/src/components/HostDetailModal.tsx
@@ -11,6 +11,8 @@ import {
 } from 'recharts';
 import axios from 'axios';
 import { useState } from 'react';
+import { useAuditLogs } from '../api/useAuditLogs';
+import AuditTimeline from '../components/AuditTimeline';
 
 interface Props {
   host: Host;
@@ -32,11 +34,12 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
   const [error, setError] = useState<string>('');
   const [success, setSuccess] = useState<string>('');
 
+  const { logs, loading } = useAuditLogs('Host', host.id);
+
   const handleSave = async () => {
     setSaving(true);
     setError('');
     setSuccess('');
-  
     try {
       const payload = {
         pipelineStage: pipelineStage.trim().toLowerCase(),
@@ -56,31 +59,21 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
     } finally {
       setSaving(false);
     }
-  };  
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg shadow-lg max-h-[90vh] overflow-y-auto relative">
-        {/* Header */}
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-semibold">Host Details: {host.name}</h3>
-          <button
-            onClick={onClose}
-            className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
-          >
+          <button onClick={onClose} className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
             <X size={20} />
           </button>
         </div>
 
-        {/* Badges for Status and Stage */}
+        {/* Status and Info */}
         <div className="flex items-center gap-4 mb-4">
-          <span
-            className={`inline-block px-2 py-1 text-xs rounded-full ${
-              host.status === 'up'
-                ? 'bg-green-100 text-green-800'
-                : 'bg-red-100 text-red-800'
-            }`}
-          >
+          <span className={`inline-block px-2 py-1 text-xs rounded-full ${host.status === 'up' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
             {capitalize(host.status)}
           </span>
           <span className="inline-block px-2 py-1 text-xs rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
@@ -88,50 +81,23 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           </span>
         </div>
 
-        {/* Info */}
         <ul className="space-y-2 text-sm mb-4">
-          <li>
-            <strong>IP:</strong> {host.ip}
-          </li>
-          <li>
-            <strong>OS:</strong> {host.os}
-          </li>
-          <li>
-            <strong>Uptime:</strong>{' '}
-            {host.uptime
-              ? `${Math.floor(host.uptime / 86400)}d ${Math.floor(
-                  (host.uptime % 86400) / 3600
-                )}h`
-              : 'N/A'}
-          </li>
-          <li>
-            <strong>CPU Usage:</strong> {host.cpu}%
-          </li>
-          <li>
-            <strong>RAM Usage:</strong> {host.ram}%
-          </li>
-          <li>
-            <strong>Disk Usage:</strong> {host.disk}%
-          </li>
-          {host.vms.length > 0 && (
-            <li>
-              <strong>Total VMs:</strong> {host.vms.length}
-            </li>
-          )}
+          <li><strong>IP:</strong> {host.ip}</li>
+          <li><strong>OS:</strong> {host.os}</li>
+          <li><strong>Uptime:</strong> {host.uptime ? `${Math.floor(host.uptime / 86400)}d ${Math.floor((host.uptime % 86400) / 3600)}h` : 'N/A'}</li>
+          <li><strong>CPU Usage:</strong> {host.cpu}%</li>
+          <li><strong>RAM Usage:</strong> {host.ram}%</li>
+          <li><strong>Disk Usage:</strong> {host.disk}%</li>
+          {host.vms.length > 0 && <li><strong>Total VMs:</strong> {host.vms.length}</li>}
         </ul>
 
-        {/* Provisioning Form */}
+        {/* Form */}
         <div className="mb-4 border-t pt-4">
           <h4 className="text-md font-medium mb-2">Provisioning Status</h4>
 
-          {/* Stage Dropdown */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Current Stage</label>
-            <select
-              className="border rounded p-1 w-full text-sm"
-              value={pipelineStage}
-              onChange={(e) => setPipelineStage(e.target.value)}
-            >
+            <select className="border rounded p-1 w-full text-sm" value={pipelineStage} onChange={(e) => setPipelineStage(e.target.value)}>
               <option value="Active">Active</option>
               <option value="Broken">Broken</option>
               <option value="Installing">Installing</option>
@@ -139,69 +105,45 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
               <option value="Staging">Staging</option>
               <option value="Unassigned">Unassigned</option>
             </select>
-            <p className="mt-1 text-xs text-gray-500">
-              Use the <strong>Notes</strong> field below to describe what’s being set up or debugged.
-            </p>
+            <p className="mt-1 text-xs text-gray-500">Use the <strong>Notes</strong> field below to describe what’s being set up or debugged.</p>
           </div>
 
-          {/* Assigned To */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Assigned To</label>
-            <input
-              type="text"
-              className="border rounded p-1 w-full text-sm"
-              placeholder="e.g. Alice"
-              value={assignedTo}
-              onChange={(e) => setAssignedTo(e.target.value)}
-            />
+            <input type="text" className="border rounded p-1 w-full text-sm" placeholder="e.g. Alice" value={assignedTo} onChange={(e) => setAssignedTo(e.target.value)} />
           </div>
 
-          {/* Notes */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Notes</label>
-            <textarea
-              className="border rounded p-1 w-full text-sm"
-              rows={3}
-              placeholder="e.g. Re-formatted disk, joined VPN, ran install.sh"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-            />
+            <textarea className="border rounded p-1 w-full text-sm" rows={3} placeholder="e.g. Re-formatted disk, joined VPN, ran install.sh" value={notes} onChange={(e) => setNotes(e.target.value)} />
           </div>
         </div>
 
-        {/* Save Controls (Sticky Footer) */}
+        {/* Save Footer */}
         <div className="sticky bottom-0 bg-white dark:bg-gray-800 pt-3 pb-4 border-t">
           <div className="flex justify-between items-center">
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className={`px-4 py-2 rounded text-white text-sm ${
-                saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'
-              }`}
-            >
+            <button onClick={handleSave} disabled={saving} className={`px-4 py-2 rounded text-white text-sm ${saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'}`}>
               {saving ? 'Saving…' : 'Save Changes'}
             </button>
-            <button
-              onClick={onClose}
-              className="text-sm underline text-gray-500 dark:text-gray-400"
-            >
-              Close
-            </button>
+            <button onClick={onClose} className="text-sm underline text-gray-500 dark:text-gray-400">Close</button>
           </div>
           {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
           {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
         </div>
 
-        {/* VM Chart */}
+        {/* Audit Timeline */}
+        <div className="mt-6 border-t pt-4">
+          <h4 className="text-sm font-bold mb-2 text-gray-700 dark:text-gray-300">Audit History</h4>
+          {loading ? <p className="text-sm text-gray-500 italic">Loading audit logs…</p> : <AuditTimeline logs={logs} />}
+        </div>
+
+        {/* VM CPU Chart */}
         {host.vms.length > 0 && (
           <div className="mt-6">
             <h4 className="text-sm font-medium mb-2">Per-VM CPU Usage:</h4>
             <div className="w-full h-48">
               <ResponsiveContainer>
-                <BarChart
-                  data={cpuData}
-                  margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
-                >
+                <BarChart data={cpuData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="name" tick={{ fontSize: 10 }} />
                   <YAxis domain={[0, 100]} allowDecimals={false} />

--- a/dashboard/src/components/HostDetailModal.tsx
+++ b/dashboard/src/components/HostDetailModal.tsx
@@ -11,14 +11,20 @@ import {
 } from 'recharts';
 import axios from 'axios';
 import { useState } from 'react';
-import { useAuditLogs } from '../api/useAuditLogs';
-import AuditTimeline from '../components/AuditTimeline';
 
 interface Props {
   host: Host;
   onClose: () => void;
   onSave: (updatedHost: Host) => void;
 }
+
+const pipelineStages = [
+  'Active',
+  'Broken',
+  'Installing',
+  'Reserved',
+  'Unassigned',
+];
 
 function capitalize(s: string) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
@@ -34,15 +40,14 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
   const [error, setError] = useState<string>('');
   const [success, setSuccess] = useState<string>('');
 
-  const { logs, loading } = useAuditLogs('Host', host.id);
-
   const handleSave = async () => {
     setSaving(true);
     setError('');
     setSuccess('');
+
     try {
       const payload = {
-        pipelineStage: pipelineStage.trim().toLowerCase(),
+        pipelineStage: pipelineStage.trim(), // Fixed: Removed toLowerCase
         assignedTo,
         notes,
       };
@@ -64,16 +69,26 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg shadow-lg max-h-[90vh] overflow-y-auto relative">
+        {/* Header */}
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-semibold">Host Details: {host.name}</h3>
-          <button onClick={onClose} className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
+          <button
+            onClick={onClose}
+            className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+          >
             <X size={20} />
           </button>
         </div>
 
-        {/* Status and Info */}
+        {/* Badges for Status and Stage */}
         <div className="flex items-center gap-4 mb-4">
-          <span className={`inline-block px-2 py-1 text-xs rounded-full ${host.status === 'up' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
+          <span
+            className={`inline-block px-2 py-1 text-xs rounded-full ${
+              host.status === 'up'
+                ? 'bg-green-100 text-green-800'
+                : 'bg-red-100 text-red-800'
+            }`}
+          >
             {capitalize(host.status)}
           </span>
           <span className="inline-block px-2 py-1 text-xs rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
@@ -81,63 +96,96 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           </span>
         </div>
 
+        {/* Info */}
         <ul className="space-y-2 text-sm mb-4">
           <li><strong>IP:</strong> {host.ip}</li>
           <li><strong>OS:</strong> {host.os}</li>
-          <li><strong>Uptime:</strong> {host.uptime ? `${Math.floor(host.uptime / 86400)}d ${Math.floor((host.uptime % 86400) / 3600)}h` : 'N/A'}</li>
+          <li>
+            <strong>Uptime:</strong>{' '}
+            {host.uptime
+              ? `${Math.floor(host.uptime / 86400)}d ${Math.floor((host.uptime % 86400) / 3600)}h`
+              : 'N/A'}
+          </li>
           <li><strong>CPU Usage:</strong> {host.cpu}%</li>
           <li><strong>RAM Usage:</strong> {host.ram}%</li>
           <li><strong>Disk Usage:</strong> {host.disk}%</li>
-          {host.vms.length > 0 && <li><strong>Total VMs:</strong> {host.vms.length}</li>}
+          {host.vms.length > 0 && (
+            <li><strong>Total VMs:</strong> {host.vms.length}</li>
+          )}
         </ul>
 
-        {/* Form */}
+        {/* Provisioning Form */}
         <div className="mb-4 border-t pt-4">
           <h4 className="text-md font-medium mb-2">Provisioning Status</h4>
 
+          {/* Stage Dropdown */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Current Stage</label>
-            <select className="border rounded p-1 w-full text-sm" value={pipelineStage} onChange={(e) => setPipelineStage(e.target.value)}>
-              <option value="Active">Active</option>
-              <option value="Broken">Broken</option>
-              <option value="Installing">Installing</option>
-              <option value="Reserved">Reserved</option>
-              <option value="Staging">Staging</option>
-              <option value="Unassigned">Unassigned</option>
+            <select
+              className="border rounded p-1 w-full text-sm"
+              value={pipelineStage}
+              onChange={(e) => setPipelineStage(e.target.value)}
+            >
+              {pipelineStages.map((stage) => (
+                <option key={stage} value={stage}>
+                  {stage}
+                </option>
+              ))}
             </select>
-            <p className="mt-1 text-xs text-gray-500">Use the <strong>Notes</strong> field below to describe what’s being set up or debugged.</p>
+            <p className="mt-1 text-xs text-gray-500">
+              Use the <strong>Notes</strong> field below to describe what’s being set up or debugged.
+            </p>
           </div>
 
+          {/* Assigned To */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Assigned To</label>
-            <input type="text" className="border rounded p-1 w-full text-sm" placeholder="e.g. Alice" value={assignedTo} onChange={(e) => setAssignedTo(e.target.value)} />
+            <input
+              type="text"
+              className="border rounded p-1 w-full text-sm"
+              placeholder="e.g. Alice"
+              value={assignedTo}
+              onChange={(e) => setAssignedTo(e.target.value)}
+            />
           </div>
 
+          {/* Notes */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Notes</label>
-            <textarea className="border rounded p-1 w-full text-sm" rows={3} placeholder="e.g. Re-formatted disk, joined VPN, ran install.sh" value={notes} onChange={(e) => setNotes(e.target.value)} />
+            <textarea
+              className="border rounded p-1 w-full text-sm"
+              rows={3}
+              placeholder="e.g. Re-formatted disk, joined VPN, ran install.sh"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
           </div>
         </div>
 
-        {/* Save Footer */}
+        {/* Save Controls */}
         <div className="sticky bottom-0 bg-white dark:bg-gray-800 pt-3 pb-4 border-t">
           <div className="flex justify-between items-center">
-            <button onClick={handleSave} disabled={saving} className={`px-4 py-2 rounded text-white text-sm ${saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'}`}>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className={`px-4 py-2 rounded text-white text-sm ${
+                saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'
+              }`}
+            >
               {saving ? 'Saving…' : 'Save Changes'}
             </button>
-            <button onClick={onClose} className="text-sm underline text-gray-500 dark:text-gray-400">Close</button>
+            <button
+              onClick={onClose}
+              className="text-sm underline text-gray-500 dark:text-gray-400"
+            >
+              Close
+            </button>
           </div>
           {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
           {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
         </div>
 
-        {/* Audit Timeline */}
-        <div className="mt-6 border-t pt-4">
-          <h4 className="text-sm font-bold mb-2 text-gray-700 dark:text-gray-300">Audit History</h4>
-          {loading ? <p className="text-sm text-gray-500 italic">Loading audit logs…</p> : <AuditTimeline logs={logs} />}
-        </div>
-
-        {/* VM CPU Chart */}
+        {/* VM Chart */}
         {host.vms.length > 0 && (
           <div className="mt-6">
             <h4 className="text-sm font-medium mb-2">Per-VM CPU Usage:</h4>

--- a/dashboard/src/components/VMDetailModal.tsx
+++ b/dashboard/src/components/VMDetailModal.tsx
@@ -2,6 +2,8 @@ import { X } from 'lucide-react';
 import type { VM } from '../api/types';
 import { useState } from 'react';
 import axios from 'axios';
+import { useAuditLogs } from '../api/useAuditLogs';
+import AuditTimeline from '../components/AuditTimeline';
 
 interface Props {
   vm: VM;
@@ -12,6 +14,7 @@ export default function VMDetailModal({ vm, onClose }: Props) {
   const [assignedTo, setAssignedTo] = useState<string>(vm.assignedTo || '');
   const [notes, setNotes] = useState<string>(vm.notes || '');
   const [saving, setSaving] = useState(false);
+  const { logs, loading } = useAuditLogs('VM', vm.id);
 
   const handleSave = async () => {
     setSaving(true);
@@ -19,9 +22,8 @@ export default function VMDetailModal({ vm, onClose }: Props) {
       await axios.put(`/api/vms/${vm.id}`, {
         ...vm,
         assignedTo,
-        notes
+        notes,
       });
-      // Optionally trigger a data refresh or toast
     } catch (err) {
       console.error('Failed to update VM:', err);
     } finally {
@@ -34,10 +36,7 @@ export default function VMDetailModal({ vm, onClose }: Props) {
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg shadow-lg max-h-[80vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-semibold">VM Details: {vm.name}</h3>
-          <button
-            onClick={onClose}
-            className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
-          >
+          <button onClick={onClose} className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
             <X size={20} />
           </button>
         </div>
@@ -54,41 +53,20 @@ export default function VMDetailModal({ vm, onClose }: Props) {
           <li><strong>MAC Address:</strong> {vm.networkMac || 'N/A'}</li>
         </ul>
 
-        {/* ─── Manual Tracking Section ───────────────────── */}
         <div className="mb-4 border-t pt-4">
           <h4 className="text-md font-medium mb-2">Manual Tracking</h4>
 
-          {/* Assigned To */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Assigned To</label>
-            <input
-              type="text"
-              className="border rounded p-1 w-full text-sm"
-              placeholder="e.g. diana"
-              value={assignedTo}
-              onChange={e => setAssignedTo(e.target.value)}
-            />
+            <input type="text" className="border rounded p-1 w-full text-sm" placeholder="e.g. diana" value={assignedTo} onChange={e => setAssignedTo(e.target.value)} />
           </div>
 
-          {/* Notes */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Notes</label>
-            <textarea
-              className="border rounded p-1 w-full text-sm"
-              rows={3}
-              placeholder="Add VM notes here…"
-              value={notes}
-              onChange={e => setNotes(e.target.value)}
-            />
+            <textarea className="border rounded p-1 w-full text-sm" rows={3} placeholder="Add VM notes here…" value={notes} onChange={e => setNotes(e.target.value)} />
           </div>
 
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className={`px-4 py-2 rounded text-white text-sm ${
-              saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'
-            }`}
-          >
+          <button onClick={handleSave} disabled={saving} className={`px-4 py-2 rounded text-white text-sm ${saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'}`}>
             {saving ? 'Saving…' : 'Save Changes'}
           </button>
         </div>
@@ -98,6 +76,11 @@ export default function VMDetailModal({ vm, onClose }: Props) {
           <pre className="bg-gray-100 dark:bg-gray-800 p-2 rounded text-xs overflow-x-auto">
             {vm.xml}
           </pre>
+        </div>
+
+        <div className="mt-6 border-t pt-4">
+          <h4 className="text-sm font-bold mb-2 text-gray-700 dark:text-gray-300">Audit History</h4>
+          {loading ? <p className="text-sm text-gray-500 italic">Loading audit logs…</p> : <AuditTimeline logs={logs} />}
         </div>
       </div>
     </div>

--- a/dashboard/src/components/VMDetailModal.tsx
+++ b/dashboard/src/components/VMDetailModal.tsx
@@ -2,8 +2,6 @@ import { X } from 'lucide-react';
 import type { VM } from '../api/types';
 import { useState } from 'react';
 import axios from 'axios';
-import { useAuditLogs } from '../api/useAuditLogs';
-import AuditTimeline from '../components/AuditTimeline';
 
 interface Props {
   vm: VM;
@@ -14,7 +12,6 @@ export default function VMDetailModal({ vm, onClose }: Props) {
   const [assignedTo, setAssignedTo] = useState<string>(vm.assignedTo || '');
   const [notes, setNotes] = useState<string>(vm.notes || '');
   const [saving, setSaving] = useState(false);
-  const { logs, loading } = useAuditLogs('VM', vm.id);
 
   const handleSave = async () => {
     setSaving(true);
@@ -22,8 +19,9 @@ export default function VMDetailModal({ vm, onClose }: Props) {
       await axios.put(`/api/vms/${vm.id}`, {
         ...vm,
         assignedTo,
-        notes,
+        notes
       });
+      // Optionally trigger a data refresh or toast
     } catch (err) {
       console.error('Failed to update VM:', err);
     } finally {
@@ -36,7 +34,10 @@ export default function VMDetailModal({ vm, onClose }: Props) {
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg shadow-lg max-h-[80vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-semibold">VM Details: {vm.name}</h3>
-          <button onClick={onClose} className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
+          <button
+            onClick={onClose}
+            className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+          >
             <X size={20} />
           </button>
         </div>
@@ -53,20 +54,41 @@ export default function VMDetailModal({ vm, onClose }: Props) {
           <li><strong>MAC Address:</strong> {vm.networkMac || 'N/A'}</li>
         </ul>
 
+        {/* ─── Manual Tracking Section ───────────────────── */}
         <div className="mb-4 border-t pt-4">
           <h4 className="text-md font-medium mb-2">Manual Tracking</h4>
 
+          {/* Assigned To */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Assigned To</label>
-            <input type="text" className="border rounded p-1 w-full text-sm" placeholder="e.g. diana" value={assignedTo} onChange={e => setAssignedTo(e.target.value)} />
+            <input
+              type="text"
+              className="border rounded p-1 w-full text-sm"
+              placeholder="e.g. diana"
+              value={assignedTo}
+              onChange={e => setAssignedTo(e.target.value)}
+            />
           </div>
 
+          {/* Notes */}
           <div className="mb-2">
             <label className="block text-sm font-medium mb-1">Notes</label>
-            <textarea className="border rounded p-1 w-full text-sm" rows={3} placeholder="Add VM notes here…" value={notes} onChange={e => setNotes(e.target.value)} />
+            <textarea
+              className="border rounded p-1 w-full text-sm"
+              rows={3}
+              placeholder="Add VM notes here…"
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+            />
           </div>
 
-          <button onClick={handleSave} disabled={saving} className={`px-4 py-2 rounded text-white text-sm ${saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'}`}>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className={`px-4 py-2 rounded text-white text-sm ${
+              saving ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'
+            }`}
+          >
             {saving ? 'Saving…' : 'Save Changes'}
           </button>
         </div>
@@ -76,11 +98,6 @@ export default function VMDetailModal({ vm, onClose }: Props) {
           <pre className="bg-gray-100 dark:bg-gray-800 p-2 rounded text-xs overflow-x-auto">
             {vm.xml}
           </pre>
-        </div>
-
-        <div className="mt-6 border-t pt-4">
-          <h4 className="text-sm font-bold mb-2 text-gray-700 dark:text-gray-300">Audit History</h4>
-          {loading ? <p className="text-sm text-gray-500 italic">Loading audit logs…</p> : <AuditTimeline logs={logs} />}
         </div>
       </div>
     </div>

--- a/dashboard/src/context/PollingContext.tsx
+++ b/dashboard/src/context/PollingContext.tsx
@@ -29,9 +29,6 @@ export function PollingProvider({ children }: { children: ReactNode }) {
       setVMs(vmRes.data.data);
       setLastUpdated(new Date());
 
-      // 💡 Audit placeholder
-      console.log('[Audit] Data refreshed at', new Date().toISOString());
-
     } catch (err) {
       console.error('Polling failed:', err);
     } finally {

--- a/dashboard/src/pages/HostsPage.tsx
+++ b/dashboard/src/pages/HostsPage.tsx
@@ -104,7 +104,7 @@ export default function HostsPage() {
   };
 
   const handleHostSave = () => {
-    // No-op: rely on centralized polling to sync fresh host data
+    triggerRefresh();
     setModalVisible(false);
   };
 

--- a/server/prisma/migrations/20250613001905_add_audit_log/migration.sql
+++ b/server/prisma/migrations/20250613001905_add_audit_log/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "entity" TEXT NOT NULL,
+    "entityId" INTEGER NOT NULL,
+    "action" TEXT NOT NULL,
+    "field" TEXT NOT NULL,
+    "oldValue" TEXT,
+    "newValue" TEXT,
+    "user" TEXT NOT NULL,
+    "time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);

--- a/server/prisma/migrations/20250613065241_update_pipeline_enum/migration.sql
+++ b/server/prisma/migrations/20250613065241_update_pipeline_enum/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - The values [unassigned,installing,working,broken] on the enum `PipelineStage` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "PipelineStage_new" AS ENUM ('Active', 'Broken', 'Installing', 'Reserved', 'Unassigned');
+ALTER TABLE "VM" ALTER COLUMN "pipelineStage" DROP DEFAULT;
+ALTER TABLE "Host" ALTER COLUMN "pipelineStage" DROP DEFAULT;
+ALTER TABLE "Host" ALTER COLUMN "pipelineStage" TYPE "PipelineStage_new" USING ("pipelineStage"::text::"PipelineStage_new");
+ALTER TABLE "VM" ALTER COLUMN "pipelineStage" TYPE "PipelineStage_new" USING ("pipelineStage"::text::"PipelineStage_new");
+ALTER TYPE "PipelineStage" RENAME TO "PipelineStage_old";
+ALTER TYPE "PipelineStage_new" RENAME TO "PipelineStage";
+DROP TYPE "PipelineStage_old";
+ALTER TABLE "VM" ALTER COLUMN "pipelineStage" SET DEFAULT 'Unassigned';
+ALTER TABLE "Host" ALTER COLUMN "pipelineStage" SET DEFAULT 'Unassigned';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Host" ALTER COLUMN "pipelineStage" SET DEFAULT 'Unassigned';
+
+-- AlterTable
+ALTER TABLE "VM" ALTER COLUMN "pipelineStage" SET DEFAULT 'Unassigned';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -77,3 +77,15 @@ model VM {
 
   @@unique([name, hostId])
 }
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  entity    String
+  entityId  Int
+  action    String    // e.g., "update", "refresh", "create"
+  field     String    // e.g., "pipelineStage"
+  oldValue  String?   // nullable for "create" or system actions
+  newValue  String?   // nullable for "delete" actions
+  user      String    // e.g., email or "system"
+  time      DateTime  @default(now())
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -19,10 +19,11 @@ enum VMStatus {
 }
 
 enum PipelineStage {
-  unassigned
-  installing
-  working
-  broken
+  Active
+  Installing
+  Broken
+  Reserved
+  Unassigned
 }
 
 model PollHistory {
@@ -45,7 +46,7 @@ model Host {
   disk          Float          // Disk usage %
 
   // ─── Manual Tracking Fields ───────────────────────────────
-  pipelineStage PipelineStage  @default(unassigned)
+  pipelineStage PipelineStage  @default(Unassigned)
   assignedTo    String?
   notes         String?
   updatedAt     DateTime       @default(now()) @updatedAt
@@ -67,7 +68,7 @@ model VM {
   networkMac    String?        // optional MAC
 
   // ─── Manual Tracking Fields ───────────────────────────────
-  pipelineStage PipelineStage  @default(unassigned)
+  pipelineStage PipelineStage  @default(Unassigned)
   assignedTo    String?
   notes         String?
   updatedAt     DateTime       @default(now()) @updatedAt

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,8 @@ import dotenv from 'dotenv';
 import hostRoutes from './routes/host.routes';
 import vmRoutes from './routes/vm.routes';
 import pollHistoryRouter from './routes/api/poll-history';
+import auditLogRoutes from './routes/auditLogs';
+
 import { startPollingJob } from './jobs/poll-scheduler';
 
 dotenv.config();
@@ -20,6 +22,7 @@ app.get('/', (_req, res) => {
 app.use('/api/hosts', hostRoutes);
 app.use('/api/vms', vmRoutes);
 app.use('/api', pollHistoryRouter);
+app.use('/api/audit-logs', auditLogRoutes);
 
 startPollingJob();
 

--- a/server/src/routes/auditLogs.ts
+++ b/server/src/routes/auditLogs.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+
+const router = express.Router();
+const prisma = new PrismaClient(); // Initialize Prisma client
+
+// Schema to validate query params
+const querySchema = z.object({
+  entity: z.enum(['Host', 'VM']),
+  entityId: z.coerce.number().int().positive(),
+});
+
+router.get('/', async (req, res) => {
+  const parse = querySchema.safeParse(req.query);
+  if (!parse.success) {
+    return res.status(400).json({ error: 'Invalid query parameters' });
+  }
+
+  const { entity, entityId } = parse.data;
+
+  try {
+    const logs = await prisma.auditLog.findMany({
+      where: { entity, entityId },
+      orderBy: { time: 'desc' },
+    });
+
+    res.json({ data: logs });
+  } catch (err) {
+    console.error('Failed to fetch audit logs:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/auditLogs.ts
+++ b/server/src/routes/auditLogs.ts
@@ -3,9 +3,8 @@ import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 
 const router = express.Router();
-const prisma = new PrismaClient(); // Initialize Prisma client
+const prisma = new PrismaClient();
 
-// Schema to validate query params
 const querySchema = z.object({
   entity: z.enum(['Host', 'VM']),
   entityId: z.coerce.number().int().positive(),

--- a/server/src/services/host.service.ts
+++ b/server/src/services/host.service.ts
@@ -45,7 +45,7 @@ export async function createHostService(data: any) {
       cpu: data.cpu,
       ram: data.ram,
       disk: data.disk,
-      pipelineStage: data.pipelineStage as PipelineStage || PipelineStage.unassigned,
+      pipelineStage: data.pipelineStage as PipelineStage || PipelineStage.Unassigned,
       assignedTo: data.assignedTo,
       notes: data.notes
     }

--- a/server/src/services/vm.service.ts
+++ b/server/src/services/vm.service.ts
@@ -54,7 +54,7 @@ export async function createVMService(data: any) {
       xml: data.xml,
       networkIp: data.networkIp,
       networkMac: data.networkMac,
-      pipelineStage: data.pipelineStage as PipelineStage || PipelineStage.unassigned,
+      pipelineStage: data.pipelineStage as PipelineStage || PipelineStage.Unassigned,
       assignedTo: data.assignedTo,
       notes: data.notes,
       host: { connect: { id: data.hostId } }


### PR DESCRIPTION
## Summary
This PR implements the end-to-end audit-log feature:

- **Frontend**  
  - Added `src/api/useAuditLogs.ts` hook that fetches and refetches audit entries.  
  - Created `src/components/AuditTimeline.tsx` for a vertical timeline of changes.  
  - Embedded `<AuditTimeline>` in `HostDetailModal.tsx` and `VMDetailModal.tsx`, with instant reload after save.  

- **Backend**  
  - Extended `schema.prisma` with the new `AuditLog` model and ran migration `add_audit_log_table`.  
  - Added `GET /api/audit-logs?entity=Host|VM&entityId=<id>` in `server/src/routes/auditLogs.ts` (Zod-validated).  
  - Instrumented `updateHost` and `updateVM` controllers to record per-field audit entries (`action = "update"`, `user` from `x-user-email`).  
  - (Optional) Removed automatic cron “refresh” entries to avoid log noise.

## What’s Done
- Closes #21 
- Closes #22 

## Next Steps
We’re now capturing and displaying all manual change events. For future improvements (filtering, pagination, bulk export, retention policies), see the new issue below.