### PR TITLE
Use PipelineStage enum for Host flow

### DIFF
--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -1,3 +1,11 @@
+export enum PipelineStage {
+  Unassigned = 'Unassigned',
+  Active = 'Active',
+  Installing = 'Installing',
+  Reserved = 'Reserved',
+  Broken = 'Broken',
+}
+
 export interface VM {
   id: number;
   name: string;
@@ -11,7 +19,7 @@ export interface VM {
   networkIp: string | null;
   networkMac: string | null;
   hostId: number;
-  pipelineStage: string;
+  pipelineStage: PipelineStage;
   assignedTo?: string | null;
   notes?: string | null;
   updatedAt: string;
@@ -32,7 +40,7 @@ export interface Host {
   cpu: number;
   ram: number;
   disk: number;
-  pipelineStage: string;
+  pipelineStage: PipelineStage;
   assignedTo?: string | null;
   notes?: string | null;
   updatedAt: string;

--- a/dashboard/src/components/HostDetailModal.tsx
+++ b/dashboard/src/components/HostDetailModal.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 import type { Host } from '../api/types';
+import { PipelineStage } from '../api/types';
 import {
   BarChart,
   Bar,
@@ -18,23 +19,16 @@ interface Props {
   onSave: (updatedHost: Host) => void;
 }
 
-const pipelineStages = [
-  'Active',
-  'Broken',
-  'Installing',
-  'Reserved',
-  'Unassigned',
-];
+const pipelineStages = Object.values(PipelineStage);
 
 function capitalize(s: string) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
 }
 
 export default function HostDetailModal({ host, onClose, onSave }: Props) {
-  // ✅ Safely handle vms possibly being undefined
   const cpuData = host.vms?.map((vm) => ({ name: vm.name, cpu: vm.cpu })) ?? [];
 
-  const [pipelineStage, setPipelineStage] = useState<string>(host.pipelineStage);
+  const [pipelineStage, setPipelineStage] = useState<PipelineStage>(host.pipelineStage);
   const [assignedTo, setAssignedTo] = useState<string>(host.assignedTo || '');
   const [notes, setNotes] = useState<string>(host.notes || '');
   const [saving, setSaving] = useState(false);
@@ -48,7 +42,7 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
 
     try {
       const payload = {
-        pipelineStage: pipelineStage.trim(),
+        pipelineStage,
         assignedTo,
         notes,
       };
@@ -70,7 +64,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg shadow-lg max-h-[90vh] overflow-y-auto relative">
-        {/* Header */}
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-semibold">Host Details: {host.name}</h3>
           <button
@@ -81,7 +74,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           </button>
         </div>
 
-        {/* Badges */}
         <div className="flex items-center gap-4 mb-4">
           <span
             className={`inline-block px-2 py-1 text-xs rounded-full ${
@@ -97,7 +89,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           </span>
         </div>
 
-        {/* Info */}
         <ul className="space-y-2 text-sm mb-4">
           <li><strong>IP:</strong> {host.ip}</li>
           <li><strong>OS:</strong> {host.os}</li>
@@ -115,7 +106,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           ) : null}
         </ul>
 
-        {/* Provisioning Form */}
         <div className="mb-4 border-t pt-4">
           <h4 className="text-md font-medium mb-2">Provisioning Status</h4>
 
@@ -124,7 +114,7 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
             <select
               className="border rounded p-1 w-full text-sm"
               value={pipelineStage}
-              onChange={(e) => setPipelineStage(e.target.value)}
+              onChange={(e) => setPipelineStage(e.target.value as PipelineStage)}
             >
               {pipelineStages.map((stage) => (
                 <option key={stage} value={stage}>
@@ -160,7 +150,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           </div>
         </div>
 
-        {/* Save Controls */}
         <div className="sticky bottom-0 bg-white dark:bg-gray-800 pt-3 pb-4 border-t">
           <div className="flex justify-between items-center">
             <button
@@ -183,7 +172,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
           {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
         </div>
 
-        {/* VM Chart */}
         {cpuData.length > 0 && (
           <div className="mt-6">
             <h4 className="text-sm font-medium mb-2">Per-VM CPU Usage:</h4>

--- a/dashboard/src/components/HostTable.tsx
+++ b/dashboard/src/components/HostTable.tsx
@@ -87,7 +87,7 @@ export default function HostTable({
               </td>
               <td className="px-4 py-2 text-sm">
                 <span className="inline-block rounded px-2 py-0.5 text-xs bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
-                  {capitalize(host.pipelineStage)}
+                  {host.pipelineStage}
                 </span>
               </td>
               <td className="text-right px-4 py-2 text-sm">

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -3,18 +3,16 @@ import HostUptimeHistory from '../components/charts/HostUptimeHistory';
 import TopVMsChart from '../components/charts/TopVMsChart';
 import HostKPI from '../components/HostKPI';
 import { useRealTimeContext } from '../context/RealTimeContext';
+import { PipelineStage } from '../api/types';
 
 export default function Dashboard() {
   const { hosts, lastUpdated } = useRealTimeContext();
 
   const stageCounts = hosts.reduce((counts, h) => {
-    const raw = h.pipelineStage?.trim().toLowerCase() || 'unassigned';
-    const stage = ['unassigned', 'active', 'reserved', 'staging', 'installing', 'broken'].includes(raw)
-      ? raw
-      : 'unassigned';
+    const stage = h.pipelineStage || PipelineStage.Unassigned;
     counts[stage] = (counts[stage] || 0) + 1;
     return counts;
-  }, {} as Record<string, number>);
+  }, {} as Record<PipelineStage, number>);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -40,16 +38,16 @@ export default function Dashboard() {
             Pipeline Stage Summary
           </h2>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            {Object.entries(stageCounts).map(([stage, count]) => (
+            {Object.values(PipelineStage).map((stage) => (
               <div
                 key={stage}
                 className="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 flex flex-col items-center"
               >
                 <span className="text-xl font-bold text-indigo-600 dark:text-indigo-400">
-                  {count}
+                  {stageCounts[stage] || 0}
                 </span>
                 <span className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-                  {stage.charAt(0).toUpperCase() + stage.slice(1)}
+                  {stage}
                 </span>
               </div>
             ))}

--- a/dashboard/src/pages/HostsPage.tsx
+++ b/dashboard/src/pages/HostsPage.tsx
@@ -33,7 +33,6 @@ export default function HostsPage() {
   const [selectedHost, setSelectedHost] = useState<Host | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
 
-  // Extract options once hosts are available
   useEffect(() => {
     setOsOptions(Array.from(new Set(allHosts.map((h) => h.os))).sort());
     setStatusOptions(Array.from(new Set(allHosts.map((h) => h.status))).sort());
@@ -42,7 +41,6 @@ export default function HostsPage() {
     );
   }, [allHosts]);
 
-  // Filtering, sorting, pagination
   useEffect(() => {
     let list = [...allHosts];
 
@@ -86,6 +84,12 @@ export default function HostsPage() {
         return sortOrder === 'asc' ? aLen - bLen : bLen - aLen;
       }
 
+      if (sortField === 'pipelineStage') {
+        return sortOrder === 'asc'
+          ? a.pipelineStage.localeCompare(b.pipelineStage)
+          : b.pipelineStage.localeCompare(a.pipelineStage);
+      }
+
       const aStr = String(aVal);
       const bStr = String(bVal);
       return sortOrder === 'asc'
@@ -105,7 +109,6 @@ export default function HostsPage() {
 
   const handleHostSave = () => {
     setModalVisible(false);
-    // SSE will auto-update the UI
   };
 
   const start = (page - 1) * pageSize + 1;


### PR DESCRIPTION
### Summary

- Introduced a `PipelineStage` enum for all host pipeline stages.
- Replaced raw string usage across:
  - `types.ts`
  - `HostDetailModal`
  - `HostTable`
  - `Dashboard` stage summary.
- Ensures type safety, improves consistency, and prevents bugs from typos.

### Files Modified
- `src/api/types.ts`
- `src/components/HostDetailModal.tsx`
- `src/components/HostTable.tsx`
- `src/pages/Dashboard.tsx`
- `src/pages/HostsPage.tsx`

---

Closes #28 