### PR TITLE
Add toast feedback for Host save actions using Sonner

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -16,7 +16,8 @@
         "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.1",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "sonner": "^2.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4581,6 +4582,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
+      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,7 +18,8 @@
     "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "sonner": "^2.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/dashboard/src/components/HostDetailModal.tsx
+++ b/dashboard/src/components/HostDetailModal.tsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import axios from 'axios';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 interface Props {
   host: Host;
@@ -32,30 +33,18 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
   const [assignedTo, setAssignedTo] = useState<string>(host.assignedTo || '');
   const [notes, setNotes] = useState<string>(host.notes || '');
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string>('');
-  const [success, setSuccess] = useState<string>('');
 
   const handleSave = async () => {
     setSaving(true);
-    setError('');
-    setSuccess('');
-
     try {
-      const payload = {
-        pipelineStage,
-        assignedTo,
-        notes,
-      };
+      const payload = { pipelineStage, assignedTo, notes };
       await axios.put(`http://localhost:4000/api/hosts/${host.id}`, payload);
-      const updatedHost: Host = {
-        ...host,
-        ...payload,
-      };
-      setSuccess('Saved successfully!');
+      const updatedHost: Host = { ...host, ...payload };
+      toast.success(`✅ Host '${host.name}' saved!`);
       onSave(updatedHost);
     } catch (err) {
       console.error('Failed to update host:', err);
-      setError('Failed to save. Please try again.');
+      toast.error(`❌ Failed to save host`);
     } finally {
       setSaving(false);
     }
@@ -168,8 +157,6 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
               Close
             </button>
           </div>
-          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
-          {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
         </div>
 
         {cpuData.length > 0 && (

--- a/dashboard/src/components/HostDetailModal.tsx
+++ b/dashboard/src/components/HostDetailModal.tsx
@@ -40,15 +40,15 @@ export default function HostDetailModal({ host, onClose, onSave }: Props) {
       const payload = { pipelineStage, assignedTo, notes };
       await axios.put(`http://localhost:4000/api/hosts/${host.id}`, payload);
       const updatedHost: Host = { ...host, ...payload };
-      toast.success(`✅ Host '${host.name}' saved!`);
+      toast.success(`Host '${host.name}' saved successfully.`);
       onSave(updatedHost);
     } catch (err) {
       console.error('Failed to update host:', err);
-      toast.error(`❌ Failed to save host`);
+      toast.error(`Failed to save host`);
     } finally {
       setSaving(false);
     }
-  };
+  };  
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
+import { Toaster } from 'sonner';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -10,11 +11,12 @@ export default function Layout({ children }: { children: ReactNode }) {
       <Sidebar collapsed={sidebarCollapsed} />
       <div className="flex-1 flex flex-col">
         <Header onToggleSidebar={() => setSidebarCollapsed((prev) => !prev)} />
-        
+
         <main className="flex-1 p-6 space-y-6">
           {children}
         </main>
       </div>
+      <Toaster richColors position="bottom-right" />
     </div>
   );
 }


### PR DESCRIPTION
### What's New

- Added `sonner` for global toast notifications
- Wrapped app in `<Toaster />` in `Layout.tsx`
- Updated `HostDetailModal.tsx`:
  - ✅ Toast on success
  - ❌ Toast on failure
- Removed old inline success state (`setSuccess`, etc.)

### Why

- Improves UX with consistent, unobtrusive feedback
- Easier to see when something fails
- Ready to expand to other modals (e.g. VMs, Settings)

---

Closes #32 